### PR TITLE
feat(model): add mark methods to model

### DIFF
--- a/lib/game_model.rb
+++ b/lib/game_model.rb
@@ -20,6 +20,18 @@ class GameModel
 
     false
   end
+
+  def mark_uncover(row, col)
+    @board_instance.board[row][col].uncover_cell
+  end
+
+  def mark_add_flag(row, col)
+    @board_instance.board[row][col].put_flag
+  end
+
+  def mark_remove_flag(row, col)
+    @board_instance.board[row][col].delete_flag
+  end
 end
 
 GameModel.new

--- a/test/initialize_model_test.rb
+++ b/test/initialize_model_test.rb
@@ -53,4 +53,21 @@ class InitializeModelTest < Test::Unit::TestCase
       assert_equal(is_bomb, true)
     end
   end
+
+  def test_mark_uncover
+    @model.mark_uncover(0, 0)
+    assert_true(@model.board[0][0].visible)
+  end
+
+  def test_mark_add_flag
+    @model.mark_add_flag(1, 1)
+    assert_true(@model.board[1][1].flag)
+  end
+
+  def test_mark_remove_flag
+    @model.board[2][2].put_flag
+    assert_true(@model.board[2][2].flag)
+    @model.mark_remove_flag(2, 2)
+    assert_false(@model.board[2][2].flag)
+  end
 end


### PR DESCRIPTION
# Feature: add mark methods on game model 

## Description
Three methods were added to `game_model`: `mark_uncover`, `mark_add_flag`, `mark_remove_flag`. This methods allow a more fluid interaction with the game board cells.

## Special considerations
This three methods receive two arguments: `row` and `col`, that together stand for a specific cell in the board.

## Tests
3 tests, 1 for each method, in `initialize_model_test`:
- `test_mark_uncover`
- `test_mark_add_flag`
- `test_mark_remove_flag`

## Additional changes
None.