### PR TITLE
fix(model): check visibility of cell before incrementing amount of cells discovered in model

### DIFF
--- a/lib/game_model.rb
+++ b/lib/game_model.rb
@@ -6,7 +6,7 @@ require_relative 'game_view'
 
 # Model for Minesweeper
 class GameModel
-  attr_reader :board, :number_not_bombs, :board_instance
+  attr_reader :board, :number_not_bombs, :board_instance, :number_discovered
 
   def initialize(bomb_seed = 'random')
     @board_instance = Board.new(bomb_seed)

--- a/test/initialize_model_test.rb
+++ b/test/initialize_model_test.rb
@@ -57,6 +57,14 @@ class InitializeModelTest < Test::Unit::TestCase
   def test_mark_uncover
     @model.mark_uncover(0, 0)
     assert_true(@model.board[0][0].visible)
+    assert_equal(1, @model.number_discovered)
+  end
+
+  def test_mark_uncover_already_uncovered
+    @model.mark_uncover(0, 0)
+    @model.mark_uncover(0, 0)
+    assert_true(@model.board[0][0].visible)
+    assert_equal(1, @model.number_discovered)
   end
 
   def test_mark_add_flag


### PR DESCRIPTION
# Fix: check visibility of cell before incrementing amount of cells discovered in model

## Description
A validation was added in the `mark_uncover` method of the model that checks first if the cell is visible before doing the increment to the amount of cells discovered. This was done to avoid possible inconsistencies when called over a visible cell.

## Special considerations
None.

## Tests
None.

## Additional changes
Minor changes in how the board instance is accessed throughout the model to make the code more readable.