### PR TITLE
fix(controller): adjust select_coordinates input to board coordinates

### DIFF
--- a/lib/game_controller.rb
+++ b/lib/game_controller.rb
@@ -12,6 +12,7 @@ class GameController
   def start; end
 
   def select_coordinates(row, col, action = 'uncover')
+    row, col = convert_input_to_coordinates(row, col)
     case action
     when 'uncover'
       return 'game_over' if check_game_over_routine(row, col)
@@ -38,5 +39,9 @@ class GameController
       return true
     end
     false
+  end
+
+  def convert_input_to_coordinates(row, col)
+    [row - 1, col - 1]
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -20,30 +20,30 @@ class GameControllerTest < Test::Unit::TestCase
   end
 
   def test_select_coordinates_put_flag
-    status = @controller.select_coordinates(0, 0, 'put_flag')
+    status = @controller.select_coordinates(1, 1, 'put_flag')
     assert_true(@model.board[0][0].flag)
     assert_equal('next', status)
   end
 
   def test_select_coordinates_remove_flag
-    status = @controller.select_coordinates(0, 0, 'remove_flag')
+    status = @controller.select_coordinates(1, 1, 'remove_flag')
     assert_false(@model.board[0][0].flag)
     assert_equal('next', status)
   end
 
   def test_select_coordinates_uncover_is_loser
-    status = @controller.select_coordinates(0, 0, 'uncover')
+    status = @controller.select_coordinates(1, 1, 'uncover')
     assert_equal('game_over', status)
   end
 
   def test_select_coordinates_uncover_is_winner
-    (0...10).each do |row|
-      (0...10).each do |col|
-        @controller.select_coordinates(row, col, 'uncover') unless [row, col] == [0, 0] || [row, col] == [9, 9]
+    (1..10).each do |row|
+      (1..10).each do |col|
+        @controller.select_coordinates(row, col, 'uncover') unless [row, col] == [1, 1] || [row, col] == [10, 10]
       end
     end
     @view.print_board(@model.board)
-    status = @controller.select_coordinates(9, 9, 'uncover')
+    status = @controller.select_coordinates(10, 10, 'uncover')
     assert_equal('winner', status)
   end
 end


### PR DESCRIPTION
# Fix: adjust `select_coordinates` input to board coordinates

## Description
This solves issue #38

## Special considerations
None.

## Tests
None.

## Additional changes
It was required to adapt the controller tests in order to fit this change, but the functionality remained intact.